### PR TITLE
修改解压缩文件权限默认为0666的问题

### DIFF
--- a/backend/utils/file.go
+++ b/backend/utils/file.go
@@ -106,7 +106,7 @@ func DeCompress(srcFile *os.File, dstPath string) error {
 		}
 
 		// 创建新文件
-		newFile, err := os.Create(filepath.Join(dstPath, innerFile.Name))
+		newFile, err := os.OpenFile(filepath.Join(dstPath, innerFile.Name), os.O_RDWR|os.O_CREATE|os.O_TRUNC, info.Mode())
 		if err != nil {
 			log.Errorf("Unzip File Error : " + err.Error())
 			debug.PrintStack()


### PR DESCRIPTION
os.Create 默认创建权限为0666会覆盖原文件权限，会造成需要+x权限的文件没有执行权限