### PR TITLE
升级 alpine master node Dockerfile

### DIFF
--- a/docker/Dockerfile.master.alpine
+++ b/docker/Dockerfile.master.alpine
@@ -8,7 +8,15 @@ ENV GOPROXY https://mirrors.aliyun.com/goproxy/
 
 RUN go install -v ./...
 
-FROM node:8.16.0-alpine AS frontend-build
+FROM node:lts-alpine AS frontend-build
+
+ARG NPM_DISABLE_SAFE_PERM=false
+RUN if [ ${NPM_DISABLE_SAFE_PERM} = true ]; then \
+    # run the install
+    echo "info: use npm unsafe-perm mode" \
+    && npm config set unsafe-perm true \
+;fi
+
 
 ADD ./frontend /app
 WORKDIR /app


### PR DESCRIPTION
增加构建参数：NPM_DISABLE_SAFE_PERM  为true
则设置 `npm config set unsafe-perm true`
默认值为 false

升级node8.0 到 lts版本（10.x）